### PR TITLE
Fix showing error on pages with date input

### DIFF
--- a/macros/date.njk
+++ b/macros/date.njk
@@ -3,7 +3,7 @@
   {% set monthError = form.errorFor(name + "[month]") %}
   {% set yearError = form.errorFor(name + "[year]") %}
   {% set dateError = form.errorFor(name) %}
-  {% set error = form.hasErrors()  %}
+  {% set error = dayError or monthError or yearError or dateError %}
   <div class="form-group {% if error %} form-group-error {% endif %}">
     {% if label %}<label for="{{ name }}[label]" class="form-label-bold">{{ t(label) }}</label> {% endif %}
     {% if hint %}<span class="form-hint" id="dob-hint">{{ t(hint) }}</span>{% endif %}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/cmc-common-frontend",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "author": "HMCTS",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Before if any input on the page had an error a red bar was shown on the
page, because it only checked if there was an error in the form object not
date input specific fields