### PR TITLE
Make text area label not bold by default

### DIFF
--- a/macros/form.njk
+++ b/macros/form.njk
@@ -78,7 +78,7 @@
   {{ input(label, name, form, hint, 'email') }}
 {% endmacro %}
 
-{% macro textArea(label, name, form, inputClass='form-control-3-4', rows=5, labelClass='', bold = true) %}
+{% macro textArea(label, name, form, inputClass='form-control-3-4', rows=5, labelClass='', bold = false) %}
   {% set error = form.errorFor(name) %}
   <div class="form-group {% if error %} form-group-error {% endif %}">
     <label for="{{ name }}" id="{{ name }}[label]" class="form-label{% if bold %}-bold{% endif %} {{ labelClass }}">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/cmc-common-frontend",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "author": "HMCTS",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
A mistake was made to introduce a new feature and enable it everywhere by default. This changes the default.