### PR TITLE
ROC-2243: Add some ARIA options to textInputInline

### DIFF
--- a/macros/form.njk
+++ b/macros/form.njk
@@ -68,13 +68,21 @@
   </div>
 {% endmacro %}
 
-{% macro textInputInline( name, form, inputClass='', prefixClass='') %}
+{% macro textInputInline( name, form, inputClass='', prefixClass='', ariaLabelledBy='', ariaDescribedBy='') %}
   {% set error = form.errorFor(name) %}
   <label for="{{ name }}"></label>
   <span class="{{ prefixClass }}">
-    <input id="{{ name }}" name="{{ name }}"
-           class="form-control {{ inputClass }} {% if error %} form-control-error {% endif %}"
-           value="{{ form.valueFor(name) | default('') }}">
+    <input
+      id="{{ name }}" name="{{ name }}"
+      class="form-control {{ inputClass }} {% if error %} form-control-error {% endif %}"
+      value="{{ form.valueFor(name) | default('') }}"
+      {% if ariaLabelledBy %}
+        aria-labelledby="{{ ariaLabelledBy }}"
+      {% endif %}
+      {% if ariaDescribedBy %}
+        aria-describedby="{{ ariaDescribedBy }}"
+      {% endif %}
+    >
   </span>
 {% endmacro %}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/cmc-common-frontend",
-  "version": "1.24.1",
+  "version": "1.25",
   "author": "HMCTS",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Add `aria-labelledby` and `aria-describedby` to `textInputInline` macro