### PR TITLE
ROC-2005 Add id to enter manually and fix response journey

### DIFF
--- a/macros/address.njk
+++ b/macros/address.njk
@@ -138,7 +138,7 @@
   }}
 
   <div class="panel panel-border-narrow js-hidden" id="hasCorrespondenceAddress-true" aria-hidden="false">
-    <p>{{ t('All correspondence will be sent to this address. This is sometimes known as an ’address for service’.') | safe }}</p>
+    <p>{{ t('All correspondence will be sent to this address. This is sometimes known as an ‘address for service’.') | safe }}</p>
     {{ postcodeLookupAddressFragment(form, name = 'correspondenceAddress') }}
   </div>
 {% endmacro %}

--- a/macros/address.njk
+++ b/macros/address.njk
@@ -16,7 +16,7 @@
   <div class="form-group notice postcode-lookup">
     {% set enterAddressError = form.errorFor(internalName) %}
     <div class="form-group notice postcode-search-container hidden js-visible{% if enterAddressError %} form-group-error{% endif %}">
-      <label id="{{ internalName }}[label]" for="{{ internalName }}" class="form-label">{{ t('Enter a UK postcode') }}</label>
+      <label id="{{ internalName + '[label]' }}" for="{{ internalName }}" class="form-label">{{ t('Enter a UK postcode') }}</label>
       <div class="postcode-search-error hidden">
         <span class="error-message">
           {{ t('We can’t find an address for that postcode. Try again or enter the address manually.') }}
@@ -94,7 +94,7 @@
 
   <div class="form-group{{ ' form-group-error' if line1Error or line2Error else '' }}">
 
-    <label id="{{ line1Name }}[label]" class="form-label" for="{{ line1Name }}">{{ t('Address') }}</label>
+    <label id="{{ line1Name + '[label]' }}" class="form-label" for="{{ line1Name }}">{{ t('Address') }}</label>
     {% if line1Error %}
       <span class="error-message">{{ t(line1Error) }}</span>
     {% endif %}

--- a/macros/address.njk
+++ b/macros/address.njk
@@ -62,38 +62,8 @@
     </div>
 
     <div class="address js-hidden">
-        {% set line1Name = name + '[line1]' if name else 'line1' %}
-        {% set line2Name = name + '[line2]' if name else 'line2' %}
 
-        {% set line1Error = form.errorFor(line1Name) %}
-        {% set line2Error = form.errorFor(line2Name) %}
-
-      <div class="form-group{{ ' form-group-error' if line1Error or line2Error else '' }}">
-
-        <label id="{{ line1Name }}[label]" class="form-label" for="{{ line1Name }}">{{ t('Address') }}</label>
-        {% if line1Error %}
-          <span class="error-message">{{ t(line1Error) }}</span>
-        {% endif %}
-        <input id="{{ line1Name }}"
-               class="form-control address-line1 {% if line1Error %} form-control-error{% endif %}"
-               name="{{ line1Name }}"
-               autocomplete="address-line1"
-               value="{{ form.valueFor(line1Name) | default('') }}"
-        />
-        {% if line2Error %}
-          <span class="error-message">{{ t(line2Error) }}</span>
-        {% endif %}
-        <input class="form-control second-text-input address-line2 {% if line2Error %} form-control-error{% endif %}"
-               name="{{ line2Name }}"
-               autocomplete="address-line2"
-               value="{{ form.valueFor(line2Name) | default('') }}"
-               title="{{ t('Street line 2') }}"
-        />
-      </div>
-      {{ textInput('Town or city', name + '[city]' if name else 'city', form, inputClass='address-town-or-city',
-        compound=true, autocomplete = 'address-level2') }}
-      {{ textInput('Postcode', name + '[postcode]' if name else 'postcode', form, inputClass='postcode form-control-1-4',
-        autocomplete = 'postal-code') }}
+      {{ addressFragment(form, name) }}
 
       {% set addressSelectorVisibleName = name + '[addressSelectorVisible]' if name else 'addressSelectorVisible' %}
       {% set enterManuallyName = name + '[enterManually]' if name else 'enterManually' %}
@@ -111,15 +81,44 @@
              name="{{ enterManuallyName }}"
              />
     </div>
-    <a href="#" class="postcode-enter-manually">{{ t('Enter address manually') }}</a>
+    <a id="{{ name + '[enterManually]' }}" href="#" class="postcode-enter-manually">{{ t('Enter address manually') }}</a>
   </div>
 {% endmacro %}
 
 {% macro addressFragment(form, name) %}
-  {{ textInput(t('Address line 1'), name + '[line1]' if name else 'line1', form, compound=true, autocomplete = 'address-line1') }}
-  {{ textInput(t('Address line 2 (optional)'), name + '[line2]' if name else 'line2', compound=true, form, autocomplete = 'address-line2') }}
-  {{ textInput(t('Town or city'), name + '[city]' if name else 'city', form, compound=true, autocomplete = 'address-level2') }}
-  {{ textInput(t('Postcode'), name + '[postcode]' if name else 'postcode', form, inputClass='postcode', autocomplete = 'postal-code') }}
+  {% set line1Name = name + '[line1]' if name else 'line1' %}
+  {% set line2Name = name + '[line2]' if name else 'line2' %}
+
+  {% set line1Error = form.errorFor(line1Name) %}
+  {% set line2Error = form.errorFor(line2Name) %}
+
+  <div class="form-group{{ ' form-group-error' if line1Error or line2Error else '' }}">
+
+    <label id="{{ line1Name }}[label]" class="form-label" for="{{ line1Name }}">{{ t('Address') }}</label>
+    {% if line1Error %}
+      <span class="error-message">{{ t(line1Error) }}</span>
+    {% endif %}
+    <input id="{{ line1Name }}"
+           class="form-control address-line1 {% if line1Error %} form-control-error{% endif %}"
+           name="{{ line1Name }}"
+           autocomplete="address-line1"
+           value="{{ form.valueFor(line1Name) | default('') }}"
+    />
+    {% if line2Error %}
+      <span class="error-message">{{ t(line2Error) }}</span>
+    {% endif %}
+    <input id="{{ line2Name }}"
+           class="form-control second-text-input address-line2 {% if line2Error %} form-control-error{% endif %}"
+           name="{{ line2Name }}"
+           autocomplete="address-line2"
+           value="{{ form.valueFor(line2Name) | default('') }}"
+           title="{{ t('Street line 2') }}"
+    />
+  </div>
+  {{ textInput('Town or city', name + '[city]' if name else 'city', form, inputClass='address-town-or-city',
+    compound=true, autocomplete = 'address-level2') }}
+  {{ textInput('Postcode', name + '[postcode]' if name else 'postcode', form, inputClass='postcode form-control-1-4',
+    autocomplete = 'postal-code') }}
 {% endmacro %}
 
 {% macro correspondenceAddressFragment(form) %}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/cmc-common-frontend",
-  "version": "1.31.2",
+  "version": "1.31.3",
   "author": "HMCTS",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
This makes the address layout consistent for claim and response journey, and adds an ID to enter manually to make integration tests easier