### PR TITLE
ROC-2243: Add `labelClass` argument to some macros

### DIFF
--- a/macros/form.njk
+++ b/macros/form.njk
@@ -1,8 +1,8 @@
-{% macro input(label, name, form, hint, type='text', inputClass='', compound=false, autocomplete='on') %}
+{% macro input(label, name, form, hint, type='text', inputClass='', compound=false, autocomplete='on', labelClass='') %}
   {% set error = form.errorFor(name) %}
   {% set formGroupClass = 'form-group-compound' if compound else 'form-group' %}
   <div class="{{ formGroupClass }} {% if error %}form-group-error{% endif %}">
-    <label for="{{ name }}" id="{{ name }}[label]" class="form-label">{{ t(label) }}
+    <label for="{{ name }}" id="{{ name }}[label]" class="form-label {% if labelClass %}{{ labelClass }}{% endif %}">{{ t(label) }}
       {% if hint %}
         <span class="form-hint">{{ t(hint) }}</span>
       {% endif %}
@@ -103,8 +103,8 @@
 
 {% endmacro %}
 
-{% macro emailInput(label, name, form, hint='') %}
-  {{ input(label, name, form, hint, 'email') }}
+{% macro emailInput(label, name, form, hint='', labelClass='') %}
+  {{ input(label, name, form, hint, 'email', labelClass = labelClass) }}
 {% endmacro %}
 
 {% macro textArea(label, name, form, inputClass='form-control-3-4', rows=5, labelClass='', bold = false) %}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/cmc-common-frontend",
-  "version": "1.33.0",
+  "version": "1.34.0",
   "author": "HMCTS",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Add optional `labelClass` argument to some input macros.

This is to help make labels that are visually hidden and only used by
assistive technologies.