### PR TITLE
Use heading for task-list rather than bold span

### DIFF
--- a/macros/task-list.njk
+++ b/macros/task-list.njk
@@ -23,8 +23,8 @@
 {% endmacro %}
 
 {% macro taskListHeading(number, heading) %}
-  <span class="bold-medium">
+  <h2 class="task-list-heading">
     <span class="task-number">{{ number }}.</span>
     {{ heading }}
-  </span>
+  </h2>
 {% endmacro %}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/cmc-common-frontend",
-  "version": "1.37.0",
+  "version": "1.38.0",
   "author": "HMCTS",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Screen readers aren't reading out the sections when headers are being
read out
which means the context isn't is good as it could be
(CSS changes will be in a frontend PR, there is no visual change to the
page though)