### PR TITLE
Use a non-bold label for correspondence address

### DIFF
--- a/macros/address.njk
+++ b/macros/address.njk
@@ -145,7 +145,8 @@
   { label: 'Yes, add a correspondence address', value: true }
   ],
   isInline = false,
-  form = form
+  form = form,
+  labelBold = false
   )
   }}
 

--- a/macros/form.njk
+++ b/macros/form.njk
@@ -258,7 +258,7 @@
 {% endmacro %}
 
 {% macro radioGroup(
-    label, name, options, form, isInline = false, legendHidden = false, labelForScreenReadersOnly = false
+    label, name, options, form, isInline = false, legendHidden = false, labelForScreenReadersOnly = false, labelBold = true
   ) %}
 
   {% set error = form.errorFor(name) %}
@@ -266,7 +266,7 @@
   <div class="form-group {% if error %} form-group-error {% endif %}">
     <fieldset name="{{ name }}[label]" id="{{ name }}[label]" {% if isInline %} class="inline" {% endif %}>
       <legend {% if legendHidden %}class="visuallyhidden"{% endif %}>
-        <span class="{% if labelForScreenReadersOnly %}visually-hidden{% else %} form-label-bold {% endif %}">
+        <span class="{% if labelForScreenReadersOnly %}visually-hidden{% elseif labelBold %} form-label-bold {% endif %}">
           {{ t(label) }}
         </span>
         <span class="error-message">{{ t(error) }}</span>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/cmc-common-frontend",
-  "version": "1.42.0",
+  "version": "1.43.0",
   "author": "HMCTS",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
One of the outputs of today's content sweep.

![screen shot 2018-03-20 at 17 46 32](https://user-images.githubusercontent.com/1095386/37672929-e42a1870-2c66-11e8-8781-8a6b787e80d9.png)
