### PR TITLE
ROC-4944 - Task List - make the blank not-completed status a call to action

### DIFF
--- a/macros/task-list.njk
+++ b/macros/task-list.njk
@@ -1,4 +1,4 @@
-{% macro task(link, taskName, completedSection, showIncomplete) %}
+{% macro task(link, taskName, completedSection) %}
   <div class="task">
     <a href="{{ link }}">
       <span class="task-name {%- if completedSection %} task-finished{% endif %}">
@@ -7,9 +7,9 @@
     </a>
     {% if completedSection === true %}
       <div class="task-finished">
-        <strong>{{ t("COMPLETED") }}</strong>
+        <strong>{{ t("COMPLETE") }}</strong>
       </div>
-    {% elif showIncomplete === true %}
+    {% else %}
       <div class="task-finished unfinished">
         <strong>{{ t("INCOMPLETE") }}</strong>
       </div>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/ROC-4944

-Update task list macro to display "INCOMPLETE" next to all unfinished tasks.
-Rename the "COMPLETED" label to "COMPLETE"